### PR TITLE
Speed up utxo API endpoint

### DIFF
--- a/doc/schema.md
+++ b/doc/schema.md
@@ -45,12 +45,12 @@ When the indexer is synced up to the tip of the chain, the hash of the tip is sa
 
 Each funding output (except for provably unspendable ones when `--index-unspendables` is not enabled) results in the following new rows (`H` is for history, `F` is for funding):
 
- * `"H{funding-scripthash}{funding-height}F{funding-txid:vout}{value}" → ""`
+ * `"H{funding-scripthash}{funding-height}F{funding-txid:vout}{value}" → "{funding-blockhash}"`
  * `"a{funding-address-str}" → ""` (for prefix address search, only saved when `--address-search` is enabled)
 
 Each spending input (except the coinbase) results in the following new rows (`S` is for spending):
 
- * `"H{funding-scripthash}{spending-height}S{spending-txid:vin}{funding-txid:vout}{value}" → ""`
+ * `"H{funding-scripthash}{spending-height}S{spending-txid:vin}{funding-txid:vout}{value}" → "{spending-blockhash}"`
 
  * `"S{funding-txid:vout}{spending-txid:vin}" → ""`
 

--- a/src/bin/tx-blockhash-backfill.rs
+++ b/src/bin/tx-blockhash-backfill.rs
@@ -1,0 +1,54 @@
+extern crate electrs;
+
+#[cfg(not(feature = "liquid"))]
+#[macro_use]
+extern crate log;
+
+#[cfg(not(feature = "liquid"))]
+fn main() {
+    use electrs::{
+        config::Config,
+        daemon::Daemon,
+        metrics::Metrics,
+        new_index::{FetchFrom, Indexer, Store, start_fetcher},
+        signal::Waiter,
+    };
+    use std::sync::Arc;
+
+    let signal = Waiter::start();
+    let config = Config::from_args();
+    let store = Arc::new(Store::open(&config.db_path.join("newindex"), &config));
+
+    let metrics = Metrics::new(config.monitoring_addr);
+    metrics.start();
+
+    let daemon = Arc::new(
+        Daemon::new(
+            &config.daemon_dir,
+            &config.blocks_dir,
+            config.daemon_rpc_addr,
+            config.cookie_getter(),
+            config.network_type,
+            signal,
+            &metrics,
+        )
+        .unwrap(),
+    );
+    let from = FetchFrom::BlkFiles;
+    let mut indexer = Indexer::open(Arc::clone(&store), from, &config, &metrics);
+    indexer.update(&daemon).unwrap();
+
+    let to_index = indexer.get_all_indexed_headers();
+    debug!(
+        "Re-indexing history from {} blocks using {:?}",
+        to_index.len(),
+        from
+    );
+    start_fetcher(from, &daemon, to_index)
+        .unwrap()
+        .map(|blocks| indexer.index(&blocks));
+    store.history_db().flush();
+}
+
+#[cfg(feature = "liquid")]
+fn main() {}

--- a/src/new_index/mod.rs
+++ b/src/new_index/mod.rs
@@ -6,7 +6,7 @@ mod query;
 pub mod schema;
 
 pub use self::db::{DBRow, DB};
-pub use self::fetch::{BlockEntry, FetchFrom};
+pub use self::fetch::{BlockEntry, FetchFrom, start_fetcher};
 pub use self::mempool::Mempool;
 pub use self::query::Query;
 pub use self::schema::{

--- a/src/new_index/schema.rs
+++ b/src/new_index/schema.rs
@@ -615,7 +615,7 @@ impl ChainQuery {
                     .block_hash
                     // returns None for orphaned blocks
                     .and_then(|hash| self.blockid_by_hash(&hash))
-                    .or_else(||self.tx_confirming_block(&history.get_txid()))
+                    .or_else(|| self.tx_confirming_block(&history.get_txid()))
                     .map(|block_id| (history, block_id))
             });
 
@@ -703,7 +703,7 @@ impl ChainQuery {
                 history
                     .block_hash
                     .and_then(|hash| self.blockid_by_hash(&hash))
-                    .or_else(||self.tx_confirming_block(&history.get_txid()))
+                    .or_else(|| self.tx_confirming_block(&history.get_txid()))
                     // drop history entries that were previously confirmed in a re-orged block and later
                     // confirmed again at a different height
                     .filter(|blockid| blockid.height == history.key.confirmed_height as usize)


### PR DESCRIPTION
# Problem
https://app.asana.com/0/1207145721171280/1207263892632102

# Implementation
1. Currenty we will join history db to get confirmed block meta for every funding transaction and spending transcation when iterate over all history transactions for specific address when getting utxos which will call history_db.get() every transaction. Thus slower the utxo API endpoint
2. The solution is to change the history tx schema so that when we save tx utxo into the db, we also write `blockhash` for that tx's confirmed block (at that time). And after that, when we need to calc utxos for a specific address, we look for all history txs which `blockhash` is in the best chain list (if that block is orphaned, then we will filter out that tx) using the `blockhash` saved, avoid calling `history_db.get()` for every tx to speed up lookup process for utxo delta calcultion.

# Test Plan

1. In dev, you can remove all your cached utxo by remove `cache` db under `db/signet/newindex` and re-start electrs server. For non-dev, suggest to find an address with large volume of utxos and not been cached before.
2. Call electrs API `address/:address/utxo` to fetch the utxos and see the API latency performance, in dev, this performance is significantly decrease from 6~7 seconds to milliseconds for an address with around 700 utxos
4. After code merge, need to deploy it to connect a bitcoin main net node to test performance for real bitcoin network, as now the test is only against `signet` dev net